### PR TITLE
Separate test output files

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,3 +23,8 @@ jobs:
         run: |
           cd examples
           bazel test --config=json //... --test_output=all --cache_test_results=no
+
+      - name: Test failing test
+        run: |
+          cd examples
+          ./verify_test_fails.sh

--- a/examples/Calc/features/BUILD.bazel
+++ b/examples/Calc/features/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_gherkin//gherkin:defs.bzl", "gherkin_library", "gherkin_test")
 # One lib for multiple feature files
 gherkin_library(
     name = "feature_specs",
-    srcs = glob(["**/*.feature"]),
+    srcs = [
+        "addition.feature",
+        "division.feature",
+    ],
 )
 
 gherkin_test(
@@ -33,4 +36,18 @@ gherkin_test(
     name = "division_test",
     steps = "//Calc/features/step_definitions:calculator_steps",
     deps = [":division_feature"],
+)
+
+# This test is expected to fail
+
+gherkin_library(
+    name = "failure_feature",
+    srcs = ["failure.feature"],
+)
+
+gherkin_test(
+    name = "failure_test",
+    steps = "//Calc/features/step_definitions:calculator_steps",
+    deps = [":failure_feature"],
+    tags = ["manual"],  # Marked as manual since it's expected to fail
 )

--- a/examples/Calc/features/failure.feature
+++ b/examples/Calc/features/failure.feature
@@ -1,0 +1,17 @@
+# language: en
+Feature: Addition
+  In order to avoid silly mistakes
+  As a math idiot 
+  I want to be told the sum of two numbers
+
+  Scenario Outline: Add two numbers
+    Given I have entered <input_1> into the calculator
+    And I have entered <input_2> into the calculator
+    When I press <button>
+    Then the result should be <output> on the screen
+
+  Examples:
+    | input_1 | input_2 | button | output |
+    | 20      | 30      | add    | 500    |
+    | 2       | 5       | add    | 70     |
+    | 0       | 40      | add    | 400    |

--- a/examples/Calc/features/failure.feature
+++ b/examples/Calc/features/failure.feature
@@ -1,7 +1,7 @@
 # language: en
 Feature: Addition
   In order to avoid silly mistakes
-  As a math idiot 
+  As a math idiot
   I want to be told the sum of two numbers
 
   Scenario Outline: Add two numbers

--- a/examples/verify_test_fails.sh
+++ b/examples/verify_test_fails.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Script to verify that a test fails as expected
+# This is used to test that intentionally failing tests actually fail
+
+set -e
+
+if bazel test //Calc/features:failure_test --test_output=all; then
+  echo "ERROR: Test passed but should have failed!"
+  exit 1
+else
+  echo "Test failed as expected"
+  exit 0
+fi

--- a/gherkin/cc_gherkin_wire_test.sh.tpl
+++ b/gherkin/cc_gherkin_wire_test.sh.tpl
@@ -1,12 +1,22 @@
 #!/bin/bash
-set -e
 export GHERKIN_WIRE_SOCKET="{SOCKET}"
 
-./{STEPS} &
+start_server() {
+    ./{STEPS} &
+    STEPS_PID=$!
+    sleep 1
+}
 
+trap "kill $STEPS_PID 2>/dev/null" EXIT
 mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}"
-OUTPUT_FILE="${TEST_UNDECLARED_OUTPUTS_DIR}/{OUTPUT_FILENAME}"
+TEST_FAILED=0
 
-./{CUCUMBER_RUBY} -r $RUNFILES_DIR/{FEATURE_DIR} {ADDITIONAL_CUCUMBER_ARGS} --out=${OUTPUT_FILE} $RUNFILES_DIR/{FEATURE_DIR}
+for feature_run in {FEATURE_RUN_LIST}; do
+    kill -0 $STEPS_PID 2>/dev/null || start_server
+    FEATURE_PATH="${feature_run%%:*}"
+    OUTPUT_FILE="${TEST_UNDECLARED_OUTPUTS_DIR}/${feature_run##*:}"
+    ./{CUCUMBER_RUBY} -r $RUNFILES_DIR/{FEATURE_DIR} {ADDITIONAL_CUCUMBER_ARGS} --out="${OUTPUT_FILE}" "$RUNFILES_DIR/{FEATURE_DIR}/${FEATURE_PATH}" || TEST_FAILED=1
+    cat "${OUTPUT_FILE}"
+done
 
-cat ${OUTPUT_FILE}
+exit $TEST_FAILED

--- a/gherkin/cc_gherkin_wire_test.sh.tpl
+++ b/gherkin/cc_gherkin_wire_test.sh.tpl
@@ -5,12 +5,19 @@ start_server() {
     ./{STEPS} &
     STEPS_PID=$!
     sleep 1
+    # Verify server started successfully
+    if ! kill -0 $STEPS_PID 2>/dev/null; then
+        echo "Error: Failed to start wire server" >&2
+        exit 1
+    fi
 }
 
+STEPS_PID=""
 trap "kill $STEPS_PID 2>/dev/null" EXIT
-mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}"
+mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}" || exit 1
 TEST_FAILED=0
 
+# NOTE: FEATURE_RUN_LIST is space-separated; feature filenames must not contain spaces.
 for feature_run in {FEATURE_RUN_LIST}; do
     kill -0 $STEPS_PID 2>/dev/null || start_server
     FEATURE_PATH="${feature_run%%:*}"

--- a/gherkin/defs.bzl
+++ b/gherkin/defs.bzl
@@ -83,14 +83,16 @@ def _gherkin_test(ctx):
     feature_files = []
     feature_run_list = []
     for spec in feature_specs:
-        spec_basename = spec.files.to_list()[0].basename
+        spec_file = spec.files.to_list()[0]
+        spec_basename = spec_file.basename
         f = ctx.actions.declare_file("features/" + spec_basename)
         feature_files.append(f)
-        ctx.actions.symlink(output = f, target_file = spec.files.to_list()[0])
+        ctx.actions.symlink(output = f, target_file = spec_file)
 
-        # Create unique output filename for each feature file
-        feature_name = spec_basename.replace(".feature", "")
-        output_filename = "{}_{}_output_{}.txt".format(test_label.name, feature_name, cucumber_format)
+        # Create unique output filename for each feature file by encoding the path
+        # Replace path separators to avoid collisions when multiple files have the same basename
+        encoded_path = spec_file.short_path.replace("/", "_").replace(".feature", "")
+        output_filename = "{}_{}_output_{}.txt".format(test_label.name, encoded_path, cucumber_format)
         # Format: feature_path:output_filename (separated by colon for easy parsing in bash)
         feature_run_list.append("features/{}:{}".format(spec_basename, output_filename))
 


### PR DESCRIPTION
 - Splitup the test report output file into separate output files, one per feature file. This allows easier postprocessing.
 - Introducing an integration test, which checks if failures are handled properly.
